### PR TITLE
Fix version file URL property

### DIFF
--- a/ReleaseFolder/GameData/WildBlueIndustries/0WBIProps/WBIProps.version
+++ b/ReleaseFolder/GameData/WildBlueIndustries/0WBIProps/WBIProps.version
@@ -1,6 +1,6 @@
 {
     "NAME":"WBIProps",
-    "URL":"https://raw.githubusercontent.com/Angel-125/WBIProps/main/ReleaseFolder/GameData/WildBlueIndustries/WBIProps/WBIProps.version",
+    "URL":"https://raw.githubusercontent.com/Angel-125/WBIProps/main/ReleaseFolder/GameData/WildBlueIndustries/0WBIProps/WBIProps.version",
     "DOWNLOAD":"https://github.com/Angel-125/WBIProps/releases",
     "GITHUB":
     {


### PR DESCRIPTION
Hi @Angel-125, the mod folder starts with `0`, which is missing from the version file URL.
Noticed while reviewing KSP-CKAN/NetKAN#10493.
Cheers!